### PR TITLE
Added watch-dir and debian support

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -1,0 +1,4 @@
+class transmission::apt {
+  # Noop as this should already be in stock repos on debian
+  yumrepo { 'geekery': }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,20 @@ class transmission (
   $umask                          = $transmission::params::umask,
   $upload_slots_per_torrent       = $transmission::params::upload_slots_per_torrent,
   $utp_enabled                    = $transmission::params::utp_enabled,
+  $watch_dir                      = $transmission::params::watch_dir,
+  $watch_dir_enabled              = $transmission::params::watch_dir_enabled,
 ) inherits transmission::params {
+  case $::osfamily {
+    'RedHat': {
+      $pkgman = 'yum'
+    }
+    'Debian': {
+      $pkgman = 'apt'
+    }
+    default: {
+      $pkgman = 'unknown'
+    }
+  }
   File {
     ensure => directory,
     owner  => $transuser,
@@ -83,7 +96,7 @@ class transmission (
   group { $transgroup:
     ensure => present,
   }
-  class { 'transmission::yum': } ->
+  class { "transmission::$pkgman": } ->
   package { [ 'transmission','transmission-cli','transmission-common','transmission-daemon','transmission-gtk' ]:
     ensure  => installed,
     require => Yumrepo['geekery'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,4 +66,6 @@ class transmission::params {
   $umask                          = 18
   $upload_slots_per_torrent       = 14
   $utp_enabled                    = true
+  $watch_dir                      = '/home/transmission/torrents'
+  $watch_dir_enabled              = false
 }

--- a/templates/settings.json.erb
+++ b/templates/settings.json.erb
@@ -62,5 +62,7 @@
     "trash-original-torrent-files": <%= @trash_original_torrent_files %>, 
     "umask": <%= @umask %>, 
     "upload-slots-per-torrent": <%= @upload_slots_per_torrent %>, 
-    "utp-enabled": <%= @utp_enabled %>
+    "utp-enabled": <%= @utp_enabled %>,
+    "watch-dir": <%= @watch_dir %>,
+    "watch-dir-enabled": <%= @watch_dir_enabled %>
 }


### PR DESCRIPTION
This change adds support for the watch-dir parameters and allows
the transmission daemon to be installed directly for aptitude
based distributions.
